### PR TITLE
Fix skill sorting

### DIFF
--- a/duolingo.py
+++ b/duolingo.py
@@ -94,7 +94,7 @@ class Duolingo(object):
         fields = ['username', 'bio', 'id', 'num_following', 'cohort',
                   'num_followers', 'learning_language_string', 'created',
                   'contribution_points', 'gplus_id', 'twitter_id', 'admin',
-                  'invites_left', 'location', 'fullname', 'avatar']
+                  'invites_left', 'location', 'fullname', 'avatar', 'ui_language']
 
         return self._make_dict(fields, self.user_data)
 


### PR DESCRIPTION
I saw you pulled some of the changes from my fork, so you might be interested in this. It turns out the index I used doesn't actually represent the order skills are learned in. I added a new function that infers the order based on the dependency graph. It's kind of crazy, but I couldn't find any other representation of the order you learned the skills in!
