### PR TITLE
Use properties instead of getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ lingo  = duolingo.Duolingo('kartik', password='my optional password')
 - lingo **.get_languages(abbreviations=False)**
 - lingo **.get_friends()**
 - lingo **.get_calendar(language_abbr=None)**
+- lingo **.get_streak_info()**
+- lingo **.get_certificates()**
 - lingo **.get_language_details(language_name)**
 - lingo **.get_language_progress(language_abbr)**
 - lingo **.get_known_topics(language_abbr)**
@@ -133,6 +135,37 @@ print lingo.get_friends()
  {'languages': [u'French', u'German'],
   'points': 579,
   'username': u'warrench04'}]
+```
+
+#### get_streak_info()
+
+```py
+lingo  = duolingo.Duolingo('kartik')
+print lingo.get_streak_info()
+```
+{
+    'site_streak': 141,
+    'daily_goal': 30,
+    'streak_extended_today': True
+}
+```
+
+
+#### get_certificates()
+
+```py
+lingo  = duolingo.Duolingo('kartik')
+print lingo.get_certificates()
+```
+
+```
+[{
+    u'language_string': u'German',
+    u'score': 2.09,
+    u'id': u'SgXFt9',
+    u'language': u'de',
+    u'datetime': u'1 month ago'
+}]
 ```
 
 #### get_language_details(language_name)

--- a/duolingo/__init__.py
+++ b/duolingo/__init__.py
@@ -151,6 +151,18 @@ class Duolingo(object):
         return self._make_dict(fields, self.user_data)
 
 
+    def get_certificates(self):
+        for certificate in self.user_data.certificates:
+            certificate['datetime'] = certificate['datetime'].strip()
+
+        return self.user_data.certificates
+
+
+    def get_streak_info(self):
+        fields = ['daily_goal', 'site_streak', 'streak_extended_today']
+        return self._make_dict(fields, self.user_data)
+
+
     def _is_current_language(self, abbr):
         return abbr in self.user_data.language_data.keys()
 
@@ -170,7 +182,7 @@ class Duolingo(object):
 
         fields = ['streak', 'language_string', 'level_progress', 'num_skills_learned',
                   'level_percent', 'level_points', 'points_rank', 'next_level',
-                  'level_left', 'language', 'points']
+                  'level_left', 'language', 'points', 'fluency_score', 'level']
 
         return self._make_dict(fields, self.user_data.language_data[lang])
 

--- a/duolingo/__init__.py
+++ b/duolingo/__init__.py
@@ -227,17 +227,16 @@ class Duolingo(object):
         return topics
 
 
-    settings = property(get_settings)
-    languages = property(get_languages)
-    user_info = property(get_user_info)
-    certificates = property(get_certificates)
-    streak_info = property(get_streak_info)
-    calendar = property(get_calendar)
-    language_progress = property(get_language_progress)
-    friends = property(get_friends)
-    known_words = property(get_known_words)
-    learned_skills = property(get_learned_skills)
-    known_topics = property(get_known_topics)
+attrs = [
+    'settings', 'languages', 'user_info', 'certificates', 'streak_info',
+    'calendar', 'language_progress', 'friends', 'known_words',
+    'learned_skills', 'known_topics'
+]
+
+for attr in attrs:
+    getter = getattr(Duolingo, "get_" + attr)
+    prop = property(getter)
+    setattr(Duolingo, attr, prop)
 
 
 if __name__ == '__main__':

--- a/duolingo/__init__.py
+++ b/duolingo/__init__.py
@@ -206,6 +206,7 @@ class Duolingo(object):
 
         return set(words)
 
+
     def get_learned_skills(self, lang):
         """ Return the learned skill objects sorted by the order they were
             learned in.
@@ -216,6 +217,7 @@ class Duolingo(object):
 
         return [ skill for skill in sorted(skills, key=lambda skill: skill['dependency_order']) if skill['learned'] ]
 
+
     def get_known_topics(self, lang):
         topics = []
         for topic in self.user_data.language_data[lang]['skills']:
@@ -224,6 +226,18 @@ class Duolingo(object):
 
         return topics
 
+
+    settings = property(get_settings)
+    languages = property(get_languages)
+    user_info = property(get_user_info)
+    certificates = property(get_certificates)
+    streak_info = property(get_streak_info)
+    calendar = property(get_calendar)
+    language_progress = property(get_language_progress)
+    friends = property(get_friends)
+    known_words = property(get_known_words)
+    learned_skills = property(get_learned_skills)
+    known_topics = property(get_known_topics)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With a getter:
```
lingo.get_certificates()
```
With a property
```
lingo.certificates
```

They're more pythonic, easier to read, etc etc.

We already have lots and lots of ```get_``` methods that all operate just fine. The way this is currently implemented each getter is just called behind the scenes. If someone wants to set a keyword argument, like language, they can just call the old getter just fine.

The reason I'm not using a custom __getattr__ is that not all get_* functions take no inputs. 

What do you think?

(This is branched off of #12.)