### PR TITLE
buy streak freeze function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 duolingo_api.egg-info
 .tox/
 .coverage
+dev
+dev/*

--- a/duolingo.py
+++ b/duolingo.py
@@ -50,6 +50,15 @@ class Duolingo(object):
         except:
             raise Exception('Could not get activity stream')
 
+    def buy_streak_freeze(self, abbr):
+        url = 'https://www.duolingo.com/store/purchase_item'
+        data = {'item_name': 'streak_freeze', 'learning_language': abbr}
+        request = self.session.post(url, data)
+
+        if not request.ok:
+            raise Exception('Not possible to buy streak freeze. '
+                            'May already be equipped.')
+
     def _switch_language(self, lang):
         data = {"learning_language": lang}
         url = "https://www.duolingo.com/switch_language"


### PR DESCRIPTION
Implemented a simple function to buy a streak freeze. It returns 400 if the streak freeze is already equipped, in which case an exception is raised. Still working on a way to try to distinguish when a streak freeze is already equipped from when the request simply failed.