### PR TITLE
Fix buy_item to work with API changes

### DIFF
--- a/duolingo.py
+++ b/duolingo.py
@@ -120,10 +120,10 @@ class Duolingo(object):
         return sorted(data, key=lambda user: user['points'], reverse=True)
 
     def buy_item(self, item_name, abbr):
-        url = 'https://www.duolingo.com/2017-06-30/users/{}/purchase-store-item'
+        url = 'https://www.duolingo.com/2017-06-30/users/{}/shop-items'
         url = url.format(self.user_data.id)
 
-        data = {'name': item_name, 'learningLanguage': abbr}
+        data = {'itemName': item_name, 'learningLanguage': abbr}
         request = self._make_req(url, data)
 
         """


### PR DESCRIPTION
Buying items (including streak freezes) is no longer working.
This patch fixes the buy_item call again.