### PR TITLE
Fix 401 response when no password is supplied

### DIFF
--- a/duolingo.py
+++ b/duolingo.py
@@ -25,14 +25,14 @@ class Duolingo(object):
     def __init__(self, username, password=None):
         self.username = username
         self.password = password
-        self.user_url = "https://duolingo.com/users/%s" % self.username
+        self.user_url = "https://duolingo.com/2017-06-30/users?username={}" % self.username
         self.session = requests.Session()
         self.leader_data = None
         self.jwt = None
 
         if password:
             self._login()
-
+        
         self.user_data = Struct(**self._get_data())
 
     def _make_req(self, url, data=None):
@@ -174,8 +174,7 @@ class Duolingo(object):
         """
         Get user's data from ``https://www.duolingo.com/users/<username>``.
         """
-        get = self._make_req(self.user_url).json()
-        return get
+        return self._make_req(self.user_url).json()
 
     @staticmethod
     def _make_dict(keys, array):

--- a/duolingo.py
+++ b/duolingo.py
@@ -25,7 +25,7 @@ class Duolingo(object):
     def __init__(self, username, password=None):
         self.username = username
         self.password = password
-        self.user_url = "https://duolingo.com/2017-06-30/users?username={}" % self.username
+        self.user_url = "https://duolingo.com/2017-06-30/users?username=%s" % self.username
         self.session = requests.Session()
         self.leader_data = None
         self.jwt = None


### PR DESCRIPTION
This is in response to issue #73. The old url does not appear to work for unauthenticated sessions.
The JSON error in the issue is related to the url not working.

A ```curl https://www.duolingo.com/users/eugenetriguba``` would yield an html page that says "401 Unauthorized. However, if we use the "2017-06-30" version of the API, we see ```curl https://www.duolingo.com/2017-06-30/users\?username\=eugenetriguba``` returns the responses we expect, even with an unauthenticated session. 