### PR TITLE
Get user data without authentication and initial baseURL configuration

### DIFF
--- a/duolingo.py
+++ b/duolingo.py
@@ -101,7 +101,8 @@ class Duolingo(object):
         if attempt.get('response') == 'OK':
             self.jwt = request.headers['jwt']
             return True
-
+        if "blockScript" in attempt:
+            raise DuolingoException("Captcha was triggered")
         raise DuolingoException("Login failed")
     
     def _make_req(self, url, data=None):

--- a/duolingo.py
+++ b/duolingo.py
@@ -91,8 +91,7 @@ class Duolingo(object):
         
         Returns:
             bool -- Login success if True
-        """        
-        str
+        """       
         self.username = username
         self.password = password
 

--- a/duolingo.py
+++ b/duolingo.py
@@ -33,11 +33,6 @@ class Duolingo(object):
     _url_login = "/login?fields="
 
     def __init__(self, username="", password="", host="www.duolingo.com", base_path="/2017-06-30"):
-        if username and password:
-            self.username = username
-            self.password = password
-            self.user_url = "https://duolingo.com/users/%s" % self.username
-
         self.host = host
         self.base_path = base_path
         self.base_url = self._url_base.format(host=self.host, base_path=self.base_path)
@@ -46,9 +41,12 @@ class Duolingo(object):
         self.leader_data = None
         self.jwt = None        
 
-        if password:
-            self._login()
-            self.user_data = Struct(**self._get_data())
+        if username:
+            self.username = username
+            if password:
+                self.password = password
+                self._login()
+            self._get_user_data(username)
         self.voice_url_dict = None
 
     def _get_user_data(self, username):

--- a/duolingo.py
+++ b/duolingo.py
@@ -98,7 +98,7 @@ class Duolingo(object):
         data = {"identifier": self.username, "password": self.password}
         request = self._make_req(url, data)
         attempt = request.json()
-        if attempt.get('response') == 'OK':
+        if request.status_code == 200:
             self.jwt = request.headers['jwt']
             return True
         if "blockScript" in attempt:

--- a/duolingo.py
+++ b/duolingo.py
@@ -51,6 +51,63 @@ class Duolingo(object):
             self.user_data = Struct(**self._get_data())
         self.voice_url_dict = None
 
+    def _get_user_data(self, username):
+        """Gets user data with _get_data if logged in
+            and _get_user_data_no_auth otherwise
+        
+        Arguments:
+            username {str} -- username on Duolingo
+        """        
+        self.username = username
+        self.user_url = "https://duolingo.com/users/%s" % self.username # TODO: should be removed
+
+        data = self._get_data() if self.jwt else self._get_user_data_no_auth(username)
+        self.user_data = Struct(**data)
+
+    def _get_user_data_no_auth(self, username):
+        """Gets user data without authentication
+        
+        Arguments:
+            username {str} -- username on Duolingo
+        
+        Returns:
+            dict -- user data
+        """        
+        url = self.base_url + self._url_user_no_auth.format(username=username)
+        get = self._make_req(url).json()
+        if not "users" in get:
+            raise DuolingoException("users field not found in response")
+        if len(get["users"]) == 0:
+            raise DuolingoException("No users in response")
+        return get["users"][0]
+
+    def login(self, username, password):
+        """Authencicate
+        
+        Arguments:
+            username {str} -- username on Duolingo
+            password {str} -- user password
+        
+        Raises:
+            DuolingoException: Login failed
+        
+        Returns:
+            bool -- Login success if True
+        """        
+        str
+        self.username = username
+        self.password = password
+
+        url = self.base_url + self._url_login
+        data = {"login": self.username, "password": self.password}
+        request = self._make_req(url, data)
+        attempt = request.json()
+        if attempt.get('response') == 'OK':
+            self.jwt = request.headers['jwt']
+            return True
+
+        raise DuolingoException("Login failed")
+    
     def _make_req(self, url, data=None):
         headers = {}
         if self.jwt is not None:

--- a/duolingo.py
+++ b/duolingo.py
@@ -96,7 +96,7 @@ class Duolingo(object):
         self.password = password
 
         url = self.base_url + self._url_login
-        data = {"login": self.username, "password": self.password}
+        data = {"identifier": self.username, "password": self.password}
         request = self._make_req(url, data)
         attempt = request.json()
         if attempt.get('response') == 'OK':

--- a/duolingo.py
+++ b/duolingo.py
@@ -32,7 +32,7 @@ class Duolingo(object):
     _url_user_no_auth = "/users?username={username}"
     _url_login = "/login?fields="
 
-    def __init__(self, username="", password="", host="www.duolingo.com", base_path="/2017-06-30"):
+    def __init__(self, username, password="", *, host="www.duolingo.com", base_path="/2017-06-30"):
         self.host = host
         self.base_path = base_path
         self.base_url = self._url_base.format(host=self.host, base_path=self.base_path)
@@ -46,23 +46,22 @@ class Duolingo(object):
             if password:
                 self.password = password
                 self._login()
-            self._get_user_data(username)
+            self._get_user_data()
         self.voice_url_dict = None
 
-    def _get_user_data(self, username):
+    def _get_user_data(self):
         """Gets user data with _get_data if logged in
             and _get_user_data_no_auth otherwise
         
         Arguments:
             username {str} -- username on Duolingo
         """        
-        self.username = username
         self.user_url = "https://duolingo.com/users/%s" % self.username # TODO: should be removed
 
-        data = self._get_data() if self.jwt else self._get_user_data_no_auth(username)
+        data = self._get_data() if self.jwt else self._get_user_data_no_auth()
         self.user_data = Struct(**data)
 
-    def _get_user_data_no_auth(self, username):
+    def _get_user_data_no_auth(self):
         """Gets user data without authentication
         
         Arguments:
@@ -71,7 +70,7 @@ class Duolingo(object):
         Returns:
             dict -- user data
         """        
-        url = self.base_url + self._url_user_no_auth.format(username=username)
+        url = self.base_url + self._url_user_no_auth.format(username=self.username)
         get = self._make_req(url).json()
         if not "users" in get:
             raise DuolingoException("users field not found in response")

--- a/duolingo.py
+++ b/duolingo.py
@@ -28,18 +28,27 @@ class DuolingoException(Exception):
 class Duolingo(object):
     USER_AGENT = "Python Duolingo API/{}".format(__version__)
 
-    def __init__(self, username, password):
-        self.username = username
-        self.password = password
-        self.user_url = "https://duolingo.com/users/%s" % self.username
+    _url_base = "https://{host}{base_path}"
+    _url_user_no_auth = "/users?username={username}"
+    _url_login = "/login?fields="
+
+    def __init__(self, username="", password="", host="www.duolingo.com", base_path="/2017-06-30"):
+        if username and password:
+            self.username = username
+            self.password = password
+            self.user_url = "https://duolingo.com/users/%s" % self.username
+
+        self.host = host
+        self.base_path = base_path
+        self.base_url = self._url_base.format(host=self.host, base_path=self.base_path)
+
         self.session = requests.Session()
         self.leader_data = None
-        self.jwt = None
+        self.jwt = None        
 
         if password:
             self._login()
-
-        self.user_data = Struct(**self._get_data())
+            self.user_data = Struct(**self._get_data())
         self.voice_url_dict = None
 
     def _make_req(self, url, data=None):


### PR DESCRIPTION
Firstly, I found out that there is an endpoint to get user data without authentication.

Additionally, this PR adds initial baseURL configuration. It can be useful, since there are different baseURLs for different platforms (iOS, Android, Web) as well as different functionalities, such as leaderboards, therefore some systematic way of storing URLs is necessary.

Lastly, login in on instance initialisation might be not preferable option, the same JWT can be used, especially if many requests are done with thee same script. That is what for official Duolingo apps do.

This PR shouldn't break current implementation, this should be with backward compatibility by now.