### PR TITLE
fix 500 response from calls to /sessions

### DIFF
--- a/duolingo.py
+++ b/duolingo.py
@@ -34,7 +34,7 @@ class CaptchaException(DuolingoException):
 
 
 class Duolingo(object):
-    USER_AGENT = "Duolingo API/{}".format(__version__)
+    USER_AGENT = "Mozilla/5.0"
 
     def __init__(self, username, password=None, *, jwt=None, session_file=None):
         """

--- a/duolingo.py
+++ b/duolingo.py
@@ -34,7 +34,8 @@ class CaptchaException(DuolingoException):
 
 
 class Duolingo(object):
-    USER_AGENT = "Mozilla/5.0"
+    USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 " \
+                 "Safari/537.36 "
 
     def __init__(self, username, password=None, *, jwt=None, session_file=None):
         """

--- a/duolingo.py
+++ b/duolingo.py
@@ -35,7 +35,7 @@ class CaptchaException(DuolingoException):
 
 class Duolingo(object):
     USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 " \
-                 "Safari/537.36 "
+                 "Safari/537.36"
 
     def __init__(self, username, password=None, *, jwt=None, session_file=None):
         """


### PR DESCRIPTION
I was trying to use `get_audio_url`, but the request to `https://www.duolingo.com/2017-06-30/sessions` in `_populate_voice_url_dictionary` returned 500. After comparing requests made from a browser to this, I found that changing the user agent in the header fixed it. Maybe they are blocking atypical user agents on some routes? Not sure, but changing this fixed it for me.