### PR TITLE
implement method to get data by user ID

### DIFF
--- a/duolingo.py
+++ b/duolingo.py
@@ -121,8 +121,8 @@ class Duolingo(object):
         return resp.status_code == 200
 
     def get_user_url_by_id(self, fields=None):
-    if fields is None:
-        fields = []
+        if fields is None:
+            fields = []
         url = 'https://www.duolingo.com/2017-06-30/users/{}'.format(self.user_data.id)
         fields_params = requests.utils.requote_uri(','.join(fields))
         if fields_params:

--- a/duolingo.py
+++ b/duolingo.py
@@ -232,7 +232,7 @@ class Duolingo(object):
         except ValueError:
             raise DuolingoException('Failed to switch language')
 
-    def _get_data_by_user_id(self, fields=None):
+    def get_data_by_user_id(self, fields=None):
         """
         Get user's data from ``https://www.duolingo.com/2017-06-30/users/<user_id>``.
         """

--- a/duolingo.py
+++ b/duolingo.py
@@ -120,6 +120,13 @@ class Duolingo(object):
         resp = self._make_req(self.get_user_url())
         return resp.status_code == 200
 
+    def get_user_url_by_id(self, fields=[]):
+        url = f'https://www.duolingo.com/2017-06-30/users/{self.user_data.id}'
+        fields_params = requests.utils.requote_uri(','.join(fields))
+        if fields_params:
+            url += f'?fields={fields_params}'
+        return url
+
     def get_user_url(self):
         return "https://duolingo.com/users/%s" % self.username
 
@@ -222,6 +229,16 @@ class Duolingo(object):
                 self.user_data = Struct(**self._get_data())
         except ValueError:
             raise DuolingoException('Failed to switch language')
+
+    def _get_data_by_user_id(self, fields=[]):
+        """
+        Get user's data from ``https://www.duolingo.com/2017-06-30/users/<user_id>``.
+        """
+        get = self._make_req(self.get_user_url_by_id(fields))
+        if get.status_code == 404:
+            raise Exception('User not found')
+        else:
+            return get.json()
 
     def _get_data(self):
         """

--- a/duolingo.py
+++ b/duolingo.py
@@ -631,11 +631,7 @@ class Duolingo(object):
             raise Exception('Could not get word definition')
 
     def get_daily_xp_progress(self):
-        daily_progress_url = \
-            "https://www.duolingo.com/2017-06-30/users/" \
-            "{}?fields=xpGoal,xpGains,streakData".format(self.user_data.id)
-        daily_progress_request = self._make_req(daily_progress_url)
-        daily_progress = daily_progress_request.json()
+        daily_progress = self.get_data_by_user_id(["xpGoal", "xpGains", "streakData"])
 
         if not daily_progress:
             raise DuolingoException(

--- a/duolingo.py
+++ b/duolingo.py
@@ -120,7 +120,9 @@ class Duolingo(object):
         resp = self._make_req(self.get_user_url())
         return resp.status_code == 200
 
-    def get_user_url_by_id(self, fields=[]):
+    def get_user_url_by_id(self, fields=None):
+    if fields is None:
+        fields = []
         url = 'https://www.duolingo.com/2017-06-30/users/{}'.format(self.user_data.id)
         fields_params = requests.utils.requote_uri(','.join(fields))
         if fields_params:
@@ -230,13 +232,15 @@ class Duolingo(object):
         except ValueError:
             raise DuolingoException('Failed to switch language')
 
-    def _get_data_by_user_id(self, fields=[]):
+    def _get_data_by_user_id(self, fields=None):
         """
         Get user's data from ``https://www.duolingo.com/2017-06-30/users/<user_id>``.
         """
+        if fields is None:
+            fields = []
         get = self._make_req(self.get_user_url_by_id(fields))
         if get.status_code == 404:
-            raise Exception('User not found')
+            raise DuolingoException('User not found')
         else:
             return get.json()
 

--- a/duolingo.py
+++ b/duolingo.py
@@ -121,10 +121,10 @@ class Duolingo(object):
         return resp.status_code == 200
 
     def get_user_url_by_id(self, fields=[]):
-        url = f'https://www.duolingo.com/2017-06-30/users/{self.user_data.id}'
+        url = 'https://www.duolingo.com/2017-06-30/users/{}'.format(self.user_data.id)
         fields_params = requests.utils.requote_uri(','.join(fields))
         if fields_params:
-            url += f'?fields={fields_params}'
+            url += '?fields={}'.format(fields_params)
         return url
 
     def get_user_url(self):


### PR DESCRIPTION
This pull request implements getting user data from `https://www.duolingo.com/2017-06-30/users/{self.user_data.id}`.

This URL is currently used by Duolingo web app, also it is used in this library in the `get_daily_xp_progress`. However, it seems reasonable to have it implemented in a generic way to give users opportunity to request different data.

The reason for introducing fields is that the response is generally quite large, 760 bytes in my case and takes about 3 seconds to receive. One option is to get data on initialisation, but it is dynamic, for example after purchasing an item it has to be requested again.

It should also help users to solve #91 while keeping library code purely for an API interaction, sample code for this:
```python
import duolingo

lingo = duolingo.Duolingo('I2UpM5so', '<password>')

user_data_resp = lingo._get_data_by_user_id(['shopItems'])

search_for = 'streak_freeze'
shop_items = list(filter(
    lambda item: item["id"] == search_for,
    user_data_resp['shopItems']
))

item = shop_items[0] if shop_items else None
if item and item["quantity"]:
    print(f'Current quantity of {search_for}: {item["quantity"]}')

```

Sample output:
```bash
Current quantity of streak_freeze: 2
```