### PR TITLE
Adding set course functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Note: You are now required to provide a password to get any data from the Duolin
 - [Buy Streak Freeze](#buy-streak-freeze)
 ###### Switch account being read
 - [Set username](#set-username)
+###### Switch current course
+- [Set course](#set-course)
 ###### Language Information
 - [Get Language Details](#get-language-details)
 - [Get Language Progress](#get-language-progress)
@@ -271,6 +273,28 @@ print(lingo.get_languages())
 ['French', 'German', 'Russian', 'Chinese', 'Portuguese', 'Spanish']
 ['French']
 ```
+
+#### Set course
+`lingo.set_course(new_from_language, new_learning_language, course_name=None)`
+
+Sets the users current course, and reloads user data. This will allow you to read data about the new course.
+This will require you to be signed in as the original user. Returns True if successful, false otherwise.
+```py
+# Sample Request
+lingo = Duolingo("kartik","...")
+print(lingo..set_course("en","es"))
+
+```
+##### Parameters
+`new_from_language` (string) **required**  
+-- The language you already know that you are learning from. Needs to be the abbreviation.
+
+`new_learning_language` (string) **required**  
+-- The language you are learning. Also needs to be the abbreviation.
+
+`course_name` (string) *optional*  
+-- The course you are changing to, defaults to `DUOLINGO_<new_learning_language>_<new_from_language>`
+ 
 
 #### Get Language Details
 `lingo.get_language_details(language_name)`

--- a/duolingo.py
+++ b/duolingo.py
@@ -61,12 +61,12 @@ class Duolingo(object):
         self.user_data = Struct(**self._get_data())
         self.voice_url_dict = None
 
-    def _make_req(self, url, data=None):
+    def _make_req(self, url, data=None, mode=None):
         headers = {}
         if self.jwt is not None:
             headers['Authorization'] = 'Bearer ' + self.jwt
         headers['User-Agent'] = self.USER_AGENT
-        req = requests.Request('POST' if data else 'GET',
+        req = requests.Request(mode if mode else ('POST' if data else 'GET'),
                                url,
                                json=data,
                                headers=headers,
@@ -135,6 +135,26 @@ class Duolingo(object):
     def set_username(self, username):
         self.username = username
         self.user_data = Struct(**self._get_data())
+
+    def set_course(self, new_from_language, new_learning_language, course_name=None):
+        """
+        Changes the current course a user is using
+        :param new_from_language: The language you already know that you are learning from needs to be the abbreviation
+        :param new_learning_language: The language you are learning needs to be the abbreviation
+        :param course_name: The course you are changing to, defaults to DUOLINGO_<new_learning_language>_<new_from_language>
+        """
+        user_id = self.get_user_id()
+        data = {"courseId":
+                    ("DUOLINGO_%s_%s" %
+                     (new_learning_language,
+                      new_from_language)).upper(),
+                "fromLanguage": new_from_language,
+                "learningLanguage": new_learning_language}
+        language_url = "https://www.duolingo.com/2017-06-30/users/%d?fields=courses,currentCourse,fromLanguage,learningLanguage" % (
+            user_id)
+        response = self._make_req(language_url, data, mode="PATCH")
+        self.user_data = Struct(**self._get_data())
+        return response.ok
 
     def get_leaderboard(self, unit, before):
         """
@@ -360,6 +380,10 @@ class Duolingo(object):
                   'ui_language']
 
         return self._make_dict(fields, self.user_data)
+
+    def get_user_id(self):
+        """Get user's id."""
+        return getattr(self.user_data, "id", None)
 
     def get_streak_info(self):
         """Get user's streak informations."""
@@ -610,7 +634,6 @@ class Duolingo(object):
                 related_lexemes = word_data['related_lexemes']
                 return [w for w in overview['vocab_overview']
                         if w['lexeme_id'] in related_lexemes]
-
 
     def get_word_definition_by_id(self, lexeme_id):
         """


### PR DESCRIPTION
Although `_set_language` already exists in the library, it is limited and not public-facing.

The new set_course function allows the user to change to any language course, including those taught in other languages. 
I have added documentation to show how the function is used.